### PR TITLE
Update author is nullable

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -7,7 +7,7 @@ export class PullRequest {
 
   constructor(
     public title: string,
-    public author: string,
+    public author: string | null,
     public url: string,
     public createdAt: string,
     public mergedAt: string,

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -14,11 +14,13 @@ export class PullRequest {
     public additions: number,
     public deletions: number,
     public authoredDate: string,
-    public firstReviewedAt: string | undefined,
+    public firstReviewedAt: string | undefined
   ) {
     const mergedAtMillis = parseISO(this.mergedAt).getTime();
     this.leadTimeSeconds = (mergedAtMillis - parseISO(this.authoredDate).getTime()) / 1000;
     this.timeToMergeSeconds = (mergedAtMillis - parseISO(this.createdAt).getTime()) / 1000;
-    this.timeToMergeFromFirstReviewSeconds = this.firstReviewedAt ? (mergedAtMillis - parseISO(this.firstReviewedAt).getTime()) / 1000 : undefined;
+    this.timeToMergeFromFirstReviewSeconds = this.firstReviewedAt
+      ? (mergedAtMillis - parseISO(this.firstReviewedAt).getTime()) / 1000
+      : undefined;
   }
 }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -7,7 +7,7 @@ export class PullRequest {
 
   constructor(
     public title: string,
-    public author: string | null,
+    public author: string | undefined,
     public url: string,
     public createdAt: string,
     public mergedAt: string,

--- a/src/github.ts
+++ b/src/github.ts
@@ -112,7 +112,7 @@ async function fetchAllPullRequestsByQuery(searchQuery: string): Promise<PullReq
         (p: PullRequestNode) =>
           new PullRequest(
             p.title,
-            p.author ? p.author.login : null,
+            p.author ? p.author.login : undefined,
             p.url,
             p.createdAt,
             p.mergedAt,

--- a/src/github.ts
+++ b/src/github.ts
@@ -34,7 +34,7 @@ interface PullRequestNode {
   title: string;
   author: {
     login: string;
-  };
+  } | null;
   url: string;
   createdAt: string;
   mergedAt: string;
@@ -112,7 +112,7 @@ async function fetchAllPullRequestsByQuery(searchQuery: string): Promise<PullReq
         (p: PullRequestNode) =>
           new PullRequest(
             p.title,
-            p.author.login,
+            p.author ? p.author.login : null,
             p.url,
             p.createdAt,
             p.mergedAt,

--- a/src/github.ts
+++ b/src/github.ts
@@ -49,9 +49,9 @@ interface PullRequestNode {
   };
   reviews: {
     nodes: {
-      createdAt: string
-    }[]
-  }
+      createdAt: string;
+    }[];
+  };
 }
 
 async function fetchAllPullRequestsByQuery(searchQuery: string): Promise<PullRequest[]> {


### PR DESCRIPTION
If the author of the PullRequest deletes the account, the author will be null.

![image](https://user-images.githubusercontent.com/58712884/156500472-9250bd4a-7201-4672-b8a3-1cb3d12ae97a.png)

GraphQL Response Example
```bash
{
    "node": {
        "title": "hoge",
        "url": "https://github.com/isanasan/hoge/pull/1",
        "mergedAt": "2020-01-07T09:43:17Z",
        "author": null
    }
},
```

The following error occurs at this time.

```bash
(node:54) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'login' of null
    at /usr/local/lib/node_modules/@shibayu36/merged-pr-stat/dist/index.js:59:146
    at Array.map (<anonymous>)
    at /usr/local/lib/node_modules/@shibayu36/merged-pr-stat/dist/index.js:59:104
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async c.n.statCommand (/usr/local/lib/node_modules/@shibayu36/merged-pr-stat/dist/index.js:71:157347)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:54) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:54) [DEP0018] DeprecationWarning: Unhandled promise rejections are
deprecated. In the future, promise rejections that are not handled will
terminate the Node.js process with a non-zero exit code.
```