### PR TITLE
Add `additions` and `deletions` to `PullRequestStat`

### DIFF
--- a/src/stat-command.test.ts
+++ b/src/stat-command.test.ts
@@ -7,10 +7,12 @@ describe("createStat", () => {
     const stat = createStat(prs);
     expect(stat).toMatchInlineSnapshot(`
       Object {
+        "additions": 1040,
         "additionsAverage": 260,
         "additionsMedian": 92.5,
         "authorCount": 3,
         "count": 4,
+        "deletions": 283,
         "deletionsAverage": 70.75,
         "deletionsMedian": 23.5,
         "leadTimeSecondsAverage": 2911116,
@@ -28,10 +30,12 @@ describe("createStat", () => {
     const stat = createStat(prs);
     expect(stat).toMatchInlineSnapshot(`
       Object {
+        "additions": 1514,
         "additionsAverage": 56.074074074074076,
         "additionsMedian": 8,
         "authorCount": 16,
         "count": 27,
+        "deletions": 651,
         "deletionsAverage": 24.11111111111111,
         "deletionsMedian": 3,
         "leadTimeSecondsAverage": 633907,

--- a/src/stat-command.ts
+++ b/src/stat-command.ts
@@ -51,10 +51,10 @@ export function createStat(prs: PullRequest[]): PullRequestStat {
   return {
     count: prs.length,
     authorCount: uniq(prs.map((pr) => pr.author)).length,
-    additions: prs.map((pr) => pr.additions).reduce((a, b) => a + b, 0),
+    additions: sum(prs.map((pr) => pr.additions)),
     additionsAverage: average(prs.map((pr) => pr.additions)),
     additionsMedian: median(prs.map((pr) => pr.additions)),
-    deletions: prs.map((pr) => pr.deletions).reduce((a, b) => a + b, 0),
+    deletions: sum(prs.map((pr) => pr.deletions)),
     deletionsAverage: average(prs.map((pr) => pr.deletions)),
     deletionsMedian: median(prs.map((pr) => pr.deletions)),
     leadTimeSecondsAverage: Math.floor(average(leadTimes)),
@@ -74,6 +74,10 @@ function average(numbers: number[]): number {
 function median(numbers: number[]): number {
   if (numbers.length === 0) return 0;
   return _median(numbers);
+}
+
+function sum(numbers: number[]): number {
+  return numbers.reduce((a, b) => a + b, 0);
 }
 
 export function createPullRequestsByLog(path: string): PullRequest[] {

--- a/src/stat-command.ts
+++ b/src/stat-command.ts
@@ -28,8 +28,10 @@ export async function statCommand(options: StatCommandOptions): Promise<void> {
 interface PullRequestStat {
   count: number;
   authorCount: number;
+  additions: number;
   additionsAverage: number;
   additionsMedian: number;
+  deletions: number;
   deletionsAverage: number;
   deletionsMedian: number;
   leadTimeSecondsAverage: number;
@@ -49,8 +51,10 @@ export function createStat(prs: PullRequest[]): PullRequestStat {
   return {
     count: prs.length,
     authorCount: uniq(prs.map((pr) => pr.author)).length,
+    additions: prs.map((pr) => pr.additions).reduce((a, b) => a + b, 0),
     additionsAverage: average(prs.map((pr) => pr.additions)),
     additionsMedian: median(prs.map((pr) => pr.additions)),
+    deletions: prs.map((pr) => pr.deletions).reduce((a, b) => a + b, 0),
     deletionsAverage: average(prs.map((pr) => pr.deletions)),
     deletionsMedian: median(prs.map((pr) => pr.deletions)),
     leadTimeSecondsAverage: Math.floor(average(leadTimes)),


### PR DESCRIPTION
To better understand the current stats about additions and deletions, it's helpful to have a reference of the total additions and deletions across all PRs in the provided query.

These sums are also required to provide context to the deletions vs additions ratio. Consider these results:

```json
{
  "count": 608,
  "authorCount": 19,
  "additionsAverage": 108.30592105263158,
  "additionsMedian": 32,
  "deletionsAverage": 51.796052631578945,
  "deletionsMedian": 6,
  "leadTimeSecondsAverage": 221679,
  "leadTimeSecondsMedian": 82470,
  "timeToMergeSecondsAverage": 192855,
  "timeToMergeSecondsMedian": 80504,
  "timeToMergeFromFirstReviewSecondsAverage": 122651,
  "timeToMergeFromFirstReviewSecondsMedian": 31698
}
```
Based on these numbers, we can compute that, on average, 32.5% of the contributions were deletions. However, we still need a piece to know the total volume of deletion contributions this might represent.

In this PR:
- Add new `additions` and `deletions` attributes to the `PullRequestStat` structure